### PR TITLE
Add initial FileStore to load/store tasks from/to files

### DIFF
--- a/.task/README.txt
+++ b/.task/README.txt
@@ -1,5 +1,5 @@
 Sample hidden .task folder and tasklog data files
-tasklog entries are tab-separated.
+tasklog entries are comma-separated.
 
 SHA1 hash          = dc48bd13747aec17318491ed4b67f857c10d7231
 Seconds since 1900 = 3688099389

--- a/.task/tasklog-CodeTortoise
+++ b/.task/tasklog-CodeTortoise
@@ -1,1 +1,0 @@
-96b160462e4587c3ebe6a7f8a2098a09d25bbdb0	3688100961	3688446561	"Figure out menu options."	assignee=	status="backlog"	tags="main","stdio"	notes=[]

--- a/.task/tasklog-minimum
+++ b/.task/tasklog-minimum
@@ -1,1 +1,0 @@
-dc48bd13747aec17318491ed4b67f857c10d7231	3688358589	"Decide on hash function to use."	status="in-progress"

--- a/.task/tasklog-mtso
+++ b/.task/tasklog-mtso
@@ -1,2 +1,0 @@
-dc48bd13747aec17318491ed4b67f857c10d7231	3688099389	3688358589	"Decide on hash function to use."	assignee=	status="in-progress"	tags="hash table","core"	notes=[mtso:"Interesting choice of words...", CodeTortoise:"You should use Keccak-p sponge function."]
-00caa8c72f3ce8137411ad70434555e23d86abb8	3688100795	3688705595	"Design Main's menu."	assignee=CodeTortoise	status="backlog"	tags="main"	notes=[]

--- a/Task/FileStore.cpp
+++ b/Task/FileStore.cpp
@@ -1,0 +1,94 @@
+// FileStore.cpp
+// Task
+// CIS 22C F2016: Jinzhu Shen
+
+#include "FileStore.h"
+#include <string.h>
+
+#include <fstream>
+#include <iostream>
+using namespace std;
+
+namespace task {
+
+    string FileStore::getUser(const string& filePath) {
+        vector<string> fields;
+        split(filePath, "/-", fields);
+        return fields[fields.size() - 1];
+    }
+
+    void FileStore::split(const string &str, const string& delim, vector<string>& fileds) {
+        char *input = const_cast<char *>(str.c_str());
+        char *next_token = nullptr;
+        char *token = strtok_s(input, delim.c_str(), &next_token);
+        while (token != nullptr) {
+            // remove double quotes, if any
+            string field(token);
+            if (field.length() > 1
+                && field[0] == '\"'
+                && field[field.length() - 1] == '\"') {
+                field = field.substr(1, field.length() - 2);
+            }
+            fileds.push_back(field);
+
+            token = strtok_s(nullptr, delim.c_str(), &next_token);
+        }
+    }
+
+    const string& FileStore::getHeader() {
+        static const string header("Unique ID,Time Created,Time Due,Description,Status");
+        return header;
+    }
+
+    FileStore::FileStore(EntryManager *visitor)
+        : visitor(visitor) {
+    }
+
+    bool FileStore::load(const string& filePath) {
+        ifstream input(filePath.c_str(), ifstream::in);
+
+        if (!input) {
+            return false;
+        }
+
+        string line;
+        int i = 0;
+        while (getline(input, line)) {
+            // skip header line
+            if (i == 0) {
+                ++i;
+                continue;
+            }
+
+            vector<string> fields;
+            split(line, ",", fields);
+
+            // visitor->loadEntry();
+
+            ++i;
+        }
+        return true;
+    }
+
+    bool FileStore::store(const string& filePath) {
+        ofstream output(filePath.c_str(), ofstream::out | ofstream::trunc);
+
+        if (!output) {
+            return false;
+        }
+
+        // header line
+        output << getHeader() << endl;
+
+        // TODO: visitor->getAllEntry();
+        string id("b74c33f995843a5f53c256e196098fcce0338783");
+        long time_created = 0l;
+        long time_due = 0l;
+        string description("Implement TaskEntry data model");
+        // TaskEntryStatus status(BACKLOG);
+
+        output << id << "," << time_created << "," << time_due << "\"" << description << "\"" << endl;
+
+        return true;
+    }
+}

--- a/Task/FileStore.h
+++ b/Task/FileStore.h
@@ -1,0 +1,39 @@
+// FileStore.h
+// Task
+// CIS 22C F2016: Jinzhu Shen
+
+#ifndef TASK_FILESTORE_H
+#define TASK_FILESTORE_H
+
+#include <string>
+#include <vector>
+
+using std::string;
+using std::vector;
+#include "EntryManager.h"
+
+namespace task {
+
+    class FileStore {
+
+    private:
+
+        EntryManager *visitor;
+
+        // extract user from file path
+        string getUser(const string& filePath);
+        const string& getHeader();
+        void split(const string &str, const string& delim, vector<string>& fileds);
+
+    public:
+
+        FileStore(EntryManager *visitor);
+
+        bool load(const string& filePath);
+        // Proposed new interface: bool load(const string& filePath, vector<TaskEntry *> tasks);
+        bool store(const string& filePath);
+        // Proposed new interface: bool store(const string& filePath, vector<TaskEntry *> tasks);
+    };
+
+}
+#endif

--- a/Task/Task.vcxproj
+++ b/Task/Task.vcxproj
@@ -84,6 +84,7 @@
     <ClInclude Include="Configuration.h" />
     <ClInclude Include="c_tree.h" />
     <ClInclude Include="c_tree_impl.h" />
+    <ClInclude Include="FileStore.h" />
     <ClInclude Include="Generics\List.h" />
     <ClInclude Include="Generics\Node.h" />
     <ClInclude Include="HashEntry.h" />
@@ -104,6 +105,7 @@
     <ClInclude Include="Utilities\TaskManager.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FileStore.cpp" />
     <ClCompile Include="HashListImplementation.h" />
     <ClCompile Include="HashTableImplementation.h" />
     <ClCompile Include="Operation.cpp" />

--- a/Task/Task.vcxproj.filters
+++ b/Task/Task.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="Operation.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FileStore.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Utilities\Sha1.cpp">
@@ -120,6 +123,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Operation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FileStore.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Task/TaskEntry.cpp
+++ b/Task/TaskEntry.cpp
@@ -69,6 +69,11 @@ namespace task
 		init(input_creator, input_description, input_time_created);
 	}
 
+    TaskEntry::TaskEntry(const string& input_creator, const string& input_description, const uint64_t& input_time_created, const uint64_t& input_time_due, TaskEntryStatus& input_status)
+    {
+        init(input_creator, input_description, input_time_created, input_status, input_time_due);
+    }
+
 	TaskEntry::TaskEntry(const TaskEntry& original)
 		: unique_id(original.unique_id)
 		, time_created(original.time_created)

--- a/Task/TaskEntry.h
+++ b/Task/TaskEntry.h
@@ -52,6 +52,8 @@ namespace task
 		 */
 		TaskEntry(const string& input_creator, const string& input_description, const uint64_t& input_time_created);
 
+        TaskEntry(const string& input_creator, const string& input_description, const uint64_t& input_time_created, const uint64_t& input_time_due, TaskEntryStatus& input_status);
+
 		/**
 		 * Copy constructor
 		 */

--- a/TaskTests/FileIoTests.cpp
+++ b/TaskTests/FileIoTests.cpp
@@ -2,9 +2,7 @@
 #include "stdafx.h"      // Pre-compiled header (optimizes unit testing header file)
 #include "CppUnitTest.h" // Unit testing API
 
-// Include the header file of your class to be able to access its public functions
-// #include "[ObjectName].h" where [ObjectMain] is the name of the header file of your class.
-
+#include "FileStore.h"
 
 // Namespace of Assert::
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -15,22 +13,10 @@ namespace FileIoTests // Testing Project namespace
     {
     public:
 
-		// TODO: Need to write tests for file IO classes
-
-		// TODO: `ExampleMethodTest` should be renamed to something more descriptive
-        TEST_METHOD(ExampleMethodTest) 
+        TEST_METHOD(TestGetUser) 
         {
-            // returns true if expected and actual are equivalent
-            Assert::AreEqual(0, 0);
+            task::FileStore fileIo(nullptr);
+            Assert::AreEqual(true, fileIo.load("../.task/tasklog-mryagni"));
         }
-
-        // Once test methods are set up,
-        // run the tests through the menubar:
-        // Test > Run > All Tests
-        //
-        // This opens the test explorer
-        // Checkmark means that all Assert:: 
-        // testing statements have passed
-
     };
 }


### PR DESCRIPTION
@mtso @CodeTortoise @xiaogaba 

Here is the initial FileStore code. The changes are:

1. Load and store tasks from file path
2. Updated samples files and removed outdated ones
3. Proposing two interface to use `FileStore`: We may pass around `TaskEntry` list instead of calling `EntryManager. loadEntry()`/`unload` to load and store tasks to files. I've includes two proposed interfaces in `FileStore.h`.

Please take a look. If that's feasible, I will update the FileStore code according to the new interfaces soon later.